### PR TITLE
[Qualification filter bug fix] filter()

### DIFF
--- a/src/app/services/qualification-filter.service.ts
+++ b/src/app/services/qualification-filter.service.ts
@@ -31,7 +31,7 @@ export class QualificationFilterService extends FilterService {
 
   filterQualificationsNotUsedByEmployees(allQualifications: Qualification[], employees: Employee[]): Qualification[] {
     return allQualifications.filter(qualification => {
-      !this.filterQualificationsInUse(employees).some(inUseQualification =>
+      return !this.filterQualificationsInUse(employees).some(inUseQualification =>
         inUseQualification.id == qualification.id
       );
     });
@@ -45,9 +45,9 @@ export class QualificationFilterService extends FilterService {
   }
 
   getIntersectionOfResultSets(result1: Qualification[], result2: Qualification[]) {
-    return result1.filter(qualification1 => {
+    return result1.filter(qualification1 =>
       result2.some(qualification2 => qualification1.id == qualification2.id)
-    });
+    );
   }
 
   filterByUsagesCheckboxes(allQualifications: Qualification[], allEmployees: Employee[], isInUse: boolean, isUnused: boolean): Qualification[] {


### PR DESCRIPTION
A tiny fix for the qualification filter service. Just some brackets ... 
If you want to use the service, please merge 

Note
Tested on the Qualification-list-component branch.
The filters in the qualification component now work fine (combinations also work)